### PR TITLE
Add "topToBottom" configuration option.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -92,12 +92,17 @@ Number.prototype.pad = function (paddingLength) {
 }
 
 function doSelection(action) {
+    const config = vscode.workspace.getConfiguration('increment-selection');
+
     var editor = vscode.window.activeTextEditor;
     if (!editor) {
         return; // No open text editor
     }
 
     var selections = editor.selections;
+    if (config.topToBottom) {
+        selections.sort((a, b) => a.start.compareTo(b.start));
+    }
     var firstSelection = editor.document.getText(selections[0]);
 
     // If it is a number or nothing has been selected

--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
     ],
     "main": "./extension",
     "contributes": {
+        "configuration": {
+            "title": "increment-selection",
+            "properties": {
+                "increment-selection.topToBottom": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Increment selections from top to bottom, rather than from the selection creation order."
+                }
+            }
+        },
         "commands": [
             {
                 "command": "extension.incrementSelection",


### PR DESCRIPTION
Currently this extension increments selections based on the order in which they were created. This often creates undesirable results.

Example: [Default](https://streamable.com/owayu)

This pull request adds a configuration option to always process increments from top to bottom.

Example: [topToBottom](https://streamable.com/6bv5q)